### PR TITLE
Create a typed error for unset variables called UnsetVariableError.

### DIFF
--- a/envvar/envvar_test.go
+++ b/envvar/envvar_test.go
@@ -87,6 +87,15 @@ func TestParseCustomNameAndDefaultVal(t *testing.T) {
 	testParse(t, nil, &customNameAndDefaultVars{}, expected)
 }
 
+func TestParseRequiredVars(t *testing.T) {
+	vars := typedVars{}
+	if err := Parse(&vars); err == nil {
+		t.Errorf("Expected error because required environment variables were not set, but got none.")
+	} else if _, ok := err.(UnsetVariableError); !ok {
+		t.Errorf("Expected error type to be UnsetVariableError but got %T", err)
+	}
+}
+
 func TestParseWithInvalidArgs(t *testing.T) {
 	testCases := []struct {
 		holder        interface{}


### PR DESCRIPTION
This allows users to handle this error differently without resorting
to string comparison. Also add a test to make sure required variables
are required.
