### PR TITLE
Allow default values to be an empty string.

### DIFF
--- a/envvar/envvar.go
+++ b/envvar/envvar.go
@@ -4,9 +4,12 @@
 package envvar
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"reflect"
 	"strconv"
+	"strings"
 	"syscall"
 )
 
@@ -33,6 +36,7 @@ import (
 // was not set. It will also return an error if there was a problem converting
 // environment variable values to the proper type or setting the fields of v.
 func Parse(v interface{}) error {
+	// Make sure the type of v is what we expect.
 	typ := reflect.TypeOf(v)
 	if typ.Kind() != reflect.Ptr || typ.Elem().Kind() != reflect.Struct {
 		return fmt.Errorf("envvar: Error in Parse: type must be a pointer to a struct. Got: %T", v)
@@ -43,6 +47,7 @@ func Parse(v interface{}) error {
 		return fmt.Errorf("envvar: Error in Parse: argument cannot be nil.")
 	}
 	structVal := val.Elem()
+	// Iterate through the fields of v and set each field.
 	for i := 0; i < structType.NumField(); i++ {
 		field := structType.Field(i)
 		varName := field.Name
@@ -50,14 +55,30 @@ func Parse(v interface{}) error {
 		if customName != "" {
 			varName = customName
 		}
-		defaultVal := field.Tag.Get("default")
-		varVal, found := syscall.Getenv(varName)
-		if !found && defaultVal == "" {
-			return UnsetVariableError{VarName: varName}
+		var varVal string
+		defaultVal, foundDefault, err := getStructTag(field, "default")
+		if err != nil {
+			return err
 		}
-		if defaultVal != "" && varVal == "" {
-			varVal = defaultVal
+		envVal, foundEnv := syscall.Getenv(varName)
+		if foundEnv {
+			// If we found an environment variable corresponding to this field. Use
+			// the value of the environment variable. This overrides the default
+			// (if any).
+			varVal = envVal
+		} else {
+			if foundDefault {
+				// If we did not find an environment variable corresponding to this
+				// field, but there is a default value, use the default value.
+				varVal = defaultVal
+			} else {
+				// If we did not find an environment variable corresponding to this
+				// field and there is not a default value, we are missing a required
+				// environment variable. Return an error.
+				return UnsetVariableError{VarName: varName}
+			}
 		}
+		// Set the value of the field.
 		if err := setFieldVal(structVal.Field(i), varName, varVal); err != nil {
 			return err
 		}
@@ -75,6 +96,42 @@ type UnsetVariableError struct {
 // Error satisfies the error interface
 func (e UnsetVariableError) Error() string {
 	return fmt.Sprintf("envvar: Missing required environment variable: %s", e.VarName)
+}
+
+// getStructTag gets struct tag value with the given key. It differs from
+// Tag.Get in that it has an additional return value that indicates whether or
+// not the key was found in the struct tag. This is required to differentiate
+// between a struct tag which specifies a default value of an empty string and
+// a struct tag which does not specify a default value.
+func getStructTag(field reflect.StructField, key string) (value string, found bool, err error) {
+	buf := bytes.NewBufferString(string(field.Tag))
+	for {
+		// Read until we reach a colon. Whatever we scan is the key (plus the
+		// colon).
+		k, err := buf.ReadString(':')
+		if err != nil {
+			if err == io.EOF {
+				return "", false, nil
+			}
+			return "", false, err
+		}
+		// Read until we reach the opening quotation mark. This is the start of
+		// the value.
+		if _, err := buf.ReadString('"'); err != nil {
+			return "", false, fmt.Errorf("envvar: Invalid struct tag for field named %s. %s", field.Name, err.Error())
+		}
+		// Read until we reach the closing quotation mark. Whatever we scan is
+		// the value (plus the closing quotation mark).
+		val, err := buf.ReadString('"')
+		if err != nil {
+			return "", false, fmt.Errorf("envvar: Invalid struct tag for field named %s. %s", field.Name, err.Error())
+		}
+		// If k is equal to the key we were looking for, we have found the value.
+		// Return it.
+		if strings.TrimSpace(k[:len(k)-1]) == key {
+			return val[:len(val)-1], true, nil
+		}
+	}
 }
 
 // setFieldVal first converts v to the type of structField, then uses reflection

--- a/envvar/envvar_test.go
+++ b/envvar/envvar_test.go
@@ -87,6 +87,13 @@ func TestParseCustomNameAndDefaultVal(t *testing.T) {
 	testParse(t, nil, &customNameAndDefaultVars{}, expected)
 }
 
+func TestParseDefaultEmptyString(t *testing.T) {
+	expected := defaultEmptyStringVars{
+		Foo: "",
+	}
+	testParse(t, nil, &defaultEmptyStringVars{}, expected)
+}
+
 func TestParseRequiredVars(t *testing.T) {
 	vars := typedVars{}
 	if err := Parse(&vars); err == nil {
@@ -177,6 +184,10 @@ type defaultVars struct {
 
 type customNameAndDefaultVars struct {
 	Foo string `envvar:"BAR" default:"biz"`
+}
+
+type defaultEmptyStringVars struct {
+	Foo string `default:""`
 }
 
 func testParse(t *testing.T, vars map[string]string, holder interface{}, expected interface{}) {


### PR DESCRIPTION
Previously, because of the way reflect.Tag.GetTag works,
a default value of an empty string would be interpreted
as a default value not being provided at all. As a result,
Parse would return an error because it thought the environment
variable was required. The new implementation fixes that
shortcoming and allows you to specify a default value of an
empty string.