### PR TITLE
Recursive envvar support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,31 @@ func main() {
 	// Do something with the parsed environment variables...
 }
 ```
+
+### Nested structs
+
+go-envvar also supports nested structs.
+
+```go
+type credential struct {
+	Username string `envvar:"USERNAME"`
+	Password string `envvar:"PASSWORD"`
+}
+
+type serverEnvVars struct {
+	ServiceA credential `envvar: "SERVICE_A_`
+	ServiceB credential `envvar: "SERVICE_B_`
+}
+
+func main() {
+	vars := serverEnvVars{}
+	err := envvar.Parse(&vars)
+	// your application logic
+}
+```
+
+In this example, envvar `SERVICE_A_USERNAME` will be mapped to the field `vars.ServiceA.Username`.
+`envvar` struct tags on a struct field are interpreted as prefixes for envvar names
+for the corresponding structs.
+
+Inner struct fields can either be a struct, pointer to a struct, or an embedded field.


### PR DESCRIPTION
implements https://github.com/plaid/go-envvar/issues/10

The core use case is this:

```go

func TestParseNestedAlias(t *testing.T) {
	type Inner struct {
		X string `envvar:"X"`
	}
	type Outer struct {
		A Inner `envvar:"A_"`
		B Inner `envvar:"B_"`
	}
	vars := map[string]string{
		"A_X": "1",
		"B_X": "2",
	}
	expected := Outer{
		Inner{"1"},
		Inner{"2"},
	}
	testParse(t, vars, &Outer{}, expected)
}
```

Also, I added a bit of refactoring during the process...

Refactoring
========
Some of the reflective calls can be removed by doing a type assertion cast. The refactored logic:

```go
func maybeTextUnmarshaler(val reflect.Value) encoding.TextUnmarshaler {
	if val.CanInterface() {
		casted, ok := val.Interface().(encoding.TextUnmarshaler)
		if !ok {
			return nil
		}
		return casted
	}
	return nil
}
```

combined with helpers:

```go

// similar to maybeTextUnmarshaler, but attempt more clever things such as
// seeing the value as a pointer type.
func cleverMaybeTextUnmarshaler(structField reflect.Value) encoding.TextUnmarshaler {
	// Check if the struct field type implements the encoding.TextUnmarshaler interface.
	if m := maybeTextUnmarshaler(structField); m != nil {
		return m
	}
	// Check if *a pointer to* the struct field type implements the
	// encoding.TextUnmarshaler interface. If it does and the struct value is
	// addressable, call the UnmarshalText method using reflection.
	if structField.CanAddr() {
		if m := maybeTextUnmarshaler(structField.Addr()); m != nil {
			return m
		}
	}
	return nil
}

// setUnmarshFieldVal sees whether a given field can be decoded via TextUnmarshaler interface.
func setUnmarshFieldVal(structField reflect.Value, name string, v string) (bool, error) {
	if m := cleverMaybeTextUnmarshaler(structField); m != nil {
		err := m.UnmarshalText([]byte(v))
		if err != nil {
			return true, InvalidVariableError{name, v, err}
		}
		return true, nil
	}
	return false, nil
}
```

a new type, `structStack` has been introduced to ease traversing:

```
// structStack represents the current instance of struct that the logic
// is injecting envvars into.
type structStack struct {
	envPrefix  string
	structType reflect.Type
	structVal  reflect.Value
}
```
this is used as the method receiver for various parsing method (which is now recursive). It currently tracks the prefix of envvar, but I think struct field name can be stored & printed also, as we currently only output the missing envvar in our error message, not the field requesting for it.
