### PR TITLE
Custom behaviors & improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,9 @@ In this example, envvar `SERVICE_A_USERNAME` will be mapped to the field `vars.S
 for the corresponding structs.
 
 Inner struct fields can either be a struct, pointer to a struct, or an embedded field.
+
+## Mocking & Custom behavior.
+
+`ParseWithConfig` can be used to control the behavior of envvar parsing. It supports
+
+* `Getenv` - customize the behavior of obtaining an envvar. By default it uses `syscall.Getenv`.

--- a/envvar/envvar.go
+++ b/envvar/envvar.go
@@ -46,8 +46,6 @@ func Parse(v interface{}) error {
 type Config struct {
 	// Getenv is a custom function to retrieve envvars with.
 	Getenv func(key string) (value string, found bool)
-	// initial prefix to fetch envvars for.
-	Prefix string
 }
 
 // GetenvFn is a custom function to retrieve envvars.
@@ -57,7 +55,7 @@ type Config struct {
 // syscall.Getenv should satisfy this type signature.
 type GetenvFn func(key string) (value string, found bool)
 
-// ParseWithConfig is ...
+// ParseWithConfig allows the call to Parse() with custom configurations.
 func ParseWithConfig(v interface{}, config Config) error {
 	// Make sure the type of v is what we expect.
 	typ := reflect.TypeOf(v)
@@ -73,17 +71,17 @@ func ParseWithConfig(v interface{}, config Config) error {
 	if config.Getenv == nil {
 		config.Getenv = syscall.Getenv
 	}
-	ss := structStack{config.Prefix, structType, structVal, &config}
+	ss := structStack{"", structType, structVal, &config}
 	return ss.parseStruct()
 }
 
 // structStack represents the current instance of struct that the logic
 // is injecting envvars into.
 type structStack struct {
-	envPrefix  string
-	structType reflect.Type
-	structVal  reflect.Value
-	config     *Config
+	envPrefix  string        // prefix for the envvars.
+	structType reflect.Type  // type of the current struct that is being parsed.
+	structVal  reflect.Value // value of the current struct that is being parsed.
+	config     *Config       // reference to the config object passed to ParseWithConfig()
 }
 
 func (ss structStack) push(

--- a/envvar/error.go
+++ b/envvar/error.go
@@ -1,0 +1,71 @@
+package envvar
+
+import (
+	"fmt"
+	"strings"
+)
+
+// UnsetVariableError is returned by Parse whenever a required environment
+// variable is not set.
+type UnsetVariableError struct {
+	// VarName is the name of the required environment variable that was not set
+	VarName string
+}
+
+// InvalidFieldError is returned by Parse whenever a given struct field
+// is unsupported.
+type InvalidFieldError struct {
+	Name    string
+	Message string
+}
+
+// InvalidVariableError is returned when a given env var cannot be parsed to
+// a given struct field.
+type InvalidVariableError struct {
+	VarName  string
+	VarValue string
+	parent   error // optional
+}
+
+// InvalidArgumentError is raised when an invalid argument passed.
+type InvalidArgumentError struct {
+	message string
+}
+
+// ErrorList is list of independent errors raised by Parse
+type ErrorList struct {
+	Errors []error
+}
+
+func (e InvalidArgumentError) Error() string {
+	return "envvar: " + e.message
+}
+
+// Error satisfies the error interface
+func (e UnsetVariableError) Error() string {
+	return fmt.Sprintf("Missing required environment variable: %s", e.VarName)
+}
+
+// Error satisfies the error interface
+func (e InvalidVariableError) Error() string {
+	return fmt.Sprintf("Error parsing environment variable %s: %s (%s)", e.VarName, e.VarValue, errorOrUnknown(e.parent))
+}
+
+func (e InvalidFieldError) Error() string {
+	return fmt.Sprintf("Unsupported struct field %s: %s", e.Name, e.Message)
+
+}
+func errorOrUnknown(err error) string {
+	if err != nil {
+		return err.Error()
+	}
+	return "unknown"
+}
+
+func (e ErrorList) Error() string {
+	allErrors := []string{}
+	for _, err := range e.Errors {
+		allErrors = append(allErrors, "envvar: "+err.Error())
+	}
+	return fmt.Sprintf(strings.Join(allErrors, "\n"))
+}


### PR DESCRIPTION
* moved all errors to a separate file, as they are somewhat independent of every other types in the main file.
* added few ways to customize the behavior, via `ParseWithConfig()` function. It offers two behaviors now:
  * get envvar from something other than the actual envvar. this simplifies some of the test, as it no longer modifies the global envvar during the test run.
  * ability to specify the initial prefix. this is technically doable via the first, as you can pass in a fucntion that does `(key) -> wrapped(prefix + key)`
    but this offers somewhat simpler way to specify this.