### PR TITLE
Add ability to ignore certain fields

### DIFF
--- a/envvar/envvar.go
+++ b/envvar/envvar.go
@@ -23,7 +23,10 @@ import (
 // struct tag `envvar` can be used to specify the name of the environment
 // variable that corresponds to a field. If the `envvar` struct tag is not
 // provided, the default is to look for an environment variable with the same
-// name as the field. The struct tag `default` can be used to set the default
+// name as the field. If the `envar` struct tag is set to "-", the field will be
+// ignored by the envvar package.
+//
+// The struct tag `default` can be used to set the default
 // value for a field. The default value must be a string, but will be converted
 // to match the type of the field as needed. If the `default` struct tag is not
 // provided, the corresponding environment variable is required, and Parse will
@@ -120,6 +123,10 @@ func (ss structStack) parseStruct() error {
 func (ss structStack) parseField(field reflect.StructField, fieldVal reflect.Value) error {
 	varName := field.Name
 	customName := field.Tag.Get("envvar")
+	if customName == "-" {
+		// The struct tag "-" means we should skip this field.
+		return nil
+	}
 	if customName != "" {
 		varName = customName
 	}

--- a/envvar/envvar_test.go
+++ b/envvar/envvar_test.go
@@ -241,6 +241,21 @@ func TestParseDefaultEmptyString(t *testing.T) {
 	testParse(t, nil, &defaultEmptyStringVars{}, expected)
 }
 
+func TestParseIgnore(t *testing.T) {
+	vars := map[string]string{
+		"Foo":         "foo value",
+		"Bar":         "bar value",
+		"FooIgnored":  "ignored foo value",
+		"BarIgnored":  "ignored bar value",
+		"FuncIgnored": "ignored function value",
+	}
+	expected := someIngoredFields{
+		Foo: "foo value",
+		Bar: "bar value",
+	}
+	testParse(t, vars, &someIngoredFields{}, expected)
+}
+
 func TestParseRequiredVars(t *testing.T) {
 	vars := typedVars{}
 	err := Parse(&vars)
@@ -470,6 +485,14 @@ type customNamedVars struct {
 	Bar            int     `envvar:"BAR"`
 	MultiWord      float64 `envvar:"MULTI_WORD"`
 	DifferentNames bool    `envvar:"COMPLETELY_DIFFERENT"`
+}
+
+type someIngoredFields struct {
+	Foo         string
+	Bar         string
+	FooIgnored  string `envvar:"-"`
+	BarIgnored  int    `envvar:"-"`
+	FuncIgnored func() `envvar:"-"` // type func() can't be parsed, so this will only work if we ignore it
 }
 
 type defaultVars struct {


### PR DESCRIPTION
This PR adds the ability to ignore struct fields. Any fields with the struct tag `envvar:"-"` will be ignored by the envvar package. This is similar to how the [`encoding/json` package](https://golang.org/pkg/encoding/json/#Marshal) in the standard library works.

Fixes https://github.com/plaid/go-envvar/issues/16.